### PR TITLE
Fix GHCR access token and bump login-action version

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -18,11 +18,11 @@ jobs:
           ref: master
 
       - name: Login to ghcr
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update Dockerfile with latest version
         id: fetch_version


### PR DESCRIPTION
Hi everyone ! 👋

I have noticed that the watch workflow updating the action is failing to publish the docker image due to missing credentials.

The goal of this pull request is to address this issue by leveraging the [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) secret and updating the docker/login-action