### PR TITLE
bump checkout and upload-sarif versions

### DIFF
--- a/starter-workflow-psalm-security-scan.yml
+++ b/starter-workflow-psalm-security-scan.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Psalm Security Scan
         uses: docker://ghcr.io/psalm/psalm-security-scan
         
       - name: Import Security Analysis results into GitHub Security Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The goal of this pull request is to update actions used with Psalm Security Scan workflow as `github/codeql-action/upload-sarif@v1` has been [deprecated](https://github.com/github/codeql-action/blob/main/CHANGELOG.md#2139---18-jan-2023).

Thanks for the hint @austenstone !