### PR TITLE
Explicitly specify job permission to publish new Docker images on GHCR

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -10,6 +10,9 @@ jobs:
   docker:
     name: Push tagged docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The goal of this pull request is to explicitly grant [Write permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) to `packages` to the job in charge of publishing images to GHCR.

The `contents` permissions is set to `read` to allow the job to checkout the code.

All [other permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#assigning-permissions-to-a-specific-job) are set to `none` by default.